### PR TITLE
Feat: JWT Token Login 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.1
 require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/gofiber/fiber/v2 v2.52.5
+	github.com/golang-jwt/jwt v3.2.2+incompatible
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	golang.org/x/oauth2 v0.23.0
 	gorm.io/driver/postgres v1.5.9

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gofiber/fiber/v2 v2.52.5 h1:tWoP1MJQjGEe4GB5TUGOi7P2E0ZMMRx5ZTG4rT+yGMo=
 github.com/gofiber/fiber/v2 v2.52.5/go.mod h1:KEOE+cXMhXG0zHc9d8+E38hoX+ZN7bhOtgeF2oT6jrQ=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=

--- a/main.go
+++ b/main.go
@@ -379,6 +379,7 @@ func main() {
 	// ### Authentication
 	user.Get("/auth/login", googleLoginURLHandler)
 	user.Get("/auth/callback", googleCallbackHandler)
+	user.Get("/auth/refresh", JWTTokenRefreshHandler)
 
 	app.Listen(":3000")
 }

--- a/main.go
+++ b/main.go
@@ -67,8 +67,8 @@ type CoreCookie struct {
 }
 
 type IsSuccessResponse struct {
-	Success bool
-	Message string
+	Success bool   `json:"success"`
+	Message string `json:"message"`
 }
 
 // # Initializations
@@ -251,8 +251,6 @@ func googleCallbackHandler(c *fiber.Ctx) error {
 			HTTPOnly: true,
 		})
 
-		c.Status(301).Redirect("/?loggedIn=true")
-
 		return c.JSON(
 			IsSuccessResponse{
 				Success: true,
@@ -337,6 +335,13 @@ func JWTTokenRefreshHandler(c *fiber.Ctx) error {
 		Secure:   true,
 		HTTPOnly: true,
 	})
+
+	c.JSON(
+		IsSuccessResponse{
+			Success: true,
+			Message: "Successfully refreshed token",
+		},
+	)
 
 	return nil
 }


### PR DESCRIPTION
# `/user/auth` 

`/user/auth` 群では，Google People API 及び，JSON Web Tokens (JWT) のセッション発行・認可に関する API を実装しています．

## EndPoints
### [GET] /user/auth/login
- Google アカウントでログインを行うための URL を発行します．

### [GET] /user/auth/callback
- Google アカウントで正常にログインを行った際に，callback されます．このエンドポイントでは，JWT Token がエンコードされ，クライアントの Cookie に保存されます．通常ユーザがこの URL にアクセスすることはありません．

### [GET] /user/auth/refresh
- JWT Token には有効期限が定められていますが，このエンドポイントでは，JWT Token の再発行をすることで，有効期限を延長することができます．

## Tips

`no-database-flag` を main.go に与えることで，データベースに接続せずにこの機能をトライすることができます．

```sh
go run main.go no-database-flag
```